### PR TITLE
1.0.1 changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,17 @@
 			<version>3.13.0</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>3.1.8</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.eerojala</groupId>
 	<artifactId>wordcount.api</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<name>wordcount.api</name>
 	<description>Small API for counting words from text files</description>
 	<properties>

--- a/src/main/java/com/eerojala/wordcount/api/context/AppConfig.java
+++ b/src/main/java/com/eerojala/wordcount/api/context/AppConfig.java
@@ -1,9 +1,34 @@
 package com.eerojala.wordcount.api.context;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 @EnableCaching
 public class AppConfig {
+    @Bean
+    public CacheManager cacheManager() {
+        var cacheManager = new CaffeineCacheManager();
+        cacheManager.setCaffeine(createCaffeineCacheBuilder());
+
+        return cacheManager;
+    }
+
+    private Caffeine<Object, Object> createCaffeineCacheBuilder() {
+        return Caffeine.newBuilder()
+                .maximumWeight(10000)
+                .weigher((k, v) -> {
+                    var castedList =  (List) v;
+
+                    return castedList.size(); // Use WordCount list size as weight
+                });
+    }
+
+
 }

--- a/src/main/java/com/eerojala/wordcount/api/exception/FileReadException.java
+++ b/src/main/java/com/eerojala/wordcount/api/exception/FileReadException.java
@@ -1,0 +1,7 @@
+package com.eerojala.wordcount.api.exception;
+
+public class FileReadException extends RuntimeException{
+    public FileReadException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/eerojala/wordcount/api/service/WordCountService.java
+++ b/src/main/java/com/eerojala/wordcount/api/service/WordCountService.java
@@ -19,7 +19,7 @@ public class WordCountService {
      *
      * NOTE TO SELF:
      * @Cachable works only if the method is called from another Spring Bean, not if called internally.
-     * Also requires a config class with annotation @EnableCaching
+     * Also requires a config class with annotation @EnableCaching + giving the cache a name (at least some times).
      *
      * @param content Non-blank that has at least one unicode letter/numeric
      * @param k 1 or larger
@@ -27,6 +27,10 @@ public class WordCountService {
      */
     @Cacheable("results")
     public List<WordCount> countMostCommonWords(String content, int k) {
+        if (content == null) {
+            throw new NullPointerException("Given content cannot be null");
+        }
+
         if (content.isBlank()) {
             throw new IllegalArgumentException("Given content cannot be blank");
         }

--- a/src/main/java/com/eerojala/wordcount/api/service/WordCountService.java
+++ b/src/main/java/com/eerojala/wordcount/api/service/WordCountService.java
@@ -48,14 +48,16 @@ public class WordCountService {
     }
 
     private String cleanContent(String content) {
-        return StringUtils.normalizeSpace(content)
+        var temp = content
                 /*
                  * \p{L} = Any unicode letter, \p{N} = Any numeric
                  * i.e. remove characters which are not letters, numerics or whitespace
                  */
-                .replaceAll("[^\\p{L}\\p{N} ]", "")
+                .replaceAll("[^\\p{L}\\p{N}\r\n ]", "")
                 .trim()
                 .toLowerCase();
+
+        return StringUtils.normalizeSpace(temp);
     }
     private Map<String, Integer> mapCountPerWord(String[] words) {
         return Arrays.stream(words).collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(e -> 1)));

--- a/src/main/java/com/eerojala/wordcount/api/service/WordCountService.java
+++ b/src/main/java/com/eerojala/wordcount/api/service/WordCountService.java
@@ -55,7 +55,7 @@ public class WordCountService {
         var temp = content
                 /*
                  * \p{L} = Any unicode letter, \p{N} = Any numeric
-                 * i.e. remove characters which are not letters, numerics or whitespace
+                 * i.e. remove characters which are not letters, numerics, whitespace, carriage returns or newlines
                  */
                 .replaceAll("[^\\p{L}\\p{N}\r\n ]", "")
                 .trim()

--- a/src/main/java/com/eerojala/wordcount/api/util/MultipartFileUtil.java
+++ b/src/main/java/com/eerojala/wordcount/api/util/MultipartFileUtil.java
@@ -10,6 +10,12 @@ import java.nio.charset.StandardCharsets;
 public class MultipartFileUtil {
     private static final String NULL_POINTER_MSG = "Given file cannot be null";
 
+    /**
+     * Reads the content from the given file and returns it as UTF-8 encoded String
+     * @param file Not null
+     * @return
+     * @throws FileReadException if something went wrong during file read.
+     */
     public String readFileContent(MultipartFile file) {
         if (file == null) {
             throw new NullPointerException(NULL_POINTER_MSG);
@@ -22,6 +28,11 @@ public class MultipartFileUtil {
         }
     }
 
+    /**
+     * Returns if given file is a .txt file.
+     * @param file Not null
+     * @return
+     */
     public boolean isValidFileType(MultipartFile file) {
         if (file == null) {
             throw new NullPointerException(NULL_POINTER_MSG);

--- a/src/main/java/com/eerojala/wordcount/api/util/MultipartFileUtil.java
+++ b/src/main/java/com/eerojala/wordcount/api/util/MultipartFileUtil.java
@@ -1,14 +1,34 @@
 package com.eerojala.wordcount.api.util;
 
+import com.eerojala.wordcount.api.exception.FileReadException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 @Component
 public class MultipartFileUtil {
-    public String getFileContent(MultipartFile file) throws IOException {
-        return new String(file.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    private static final String NULL_POINTER_MSG = "Given file cannot be null";
+
+    public String readFileContent(MultipartFile file) {
+        if (file == null) {
+            throw new NullPointerException(NULL_POINTER_MSG);
+        }
+
+        try {
+            return new String(file.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new FileReadException("Error while reading file");
+        }
+    }
+
+    public boolean isValidFileType(MultipartFile file) {
+        if (file == null) {
+            throw new NullPointerException(NULL_POINTER_MSG);
+        }
+
+        String fileName = file.getOriginalFilename();
+
+        return fileName != null && fileName.toLowerCase().endsWith(".txt");
     }
 }

--- a/src/main/java/com/eerojala/wordcount/api/web/WordCountController.java
+++ b/src/main/java/com/eerojala/wordcount/api/web/WordCountController.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -21,8 +20,15 @@ public class WordCountController {
     private MultipartFileUtil fileUtil;
 
     @PostMapping("/wordcount")
-    public List<WordCount> countWords(@Valid FileAndAmountDto dto) throws IOException {
-        String content = fileUtil.getFileContent(dto.getFile());
+    public List<WordCount> countWords(@Valid FileAndAmountDto dto)  {
+        var file = dto.getFile();
+
+        if (!fileUtil.isValidFileType(file)) {
+            throw new IllegalArgumentException("Given file must be a .txt file");
+        }
+
+        String content = fileUtil.readFileContent(file);
+
         return service.countMostCommonWords(content, dto.getAmount());
     }
 }

--- a/src/main/java/com/eerojala/wordcount/api/web/WordCountExceptionHandler.java
+++ b/src/main/java/com/eerojala/wordcount/api/web/WordCountExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.eerojala.wordcount.api.web;
 
-import org.apache.tomcat.util.http.fileupload.FileUploadException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -12,20 +11,6 @@ import java.util.ArrayList;
 
 @RestControllerAdvice
 public class WordCountExceptionHandler {
-    @ExceptionHandler(IllegalArgumentException.class)
-    @ResponseBody
-    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException exception) {
-        return createBadRequestResponse(exception.getMessage());
-    }
-
-    private ResponseEntity<ErrorResponse> createBadRequestResponse(String errorMsg) {
-        return createResponse(errorMsg, HttpStatus.BAD_REQUEST);
-    }
-
-    private ResponseEntity<ErrorResponse> createResponse(String errorMsg, HttpStatus httpStatus) {
-        return ResponseEntity.status(httpStatus).body(new ErrorResponse(errorMsg));
-    }
-
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseBody
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
@@ -42,9 +27,17 @@ public class WordCountExceptionHandler {
         }
     }
 
-    @ExceptionHandler(FileUploadException.class)
+    private ResponseEntity<ErrorResponse> createBadRequestResponse(String errorMsg) {
+        return createResponse(errorMsg, HttpStatus.BAD_REQUEST);
+    }
+
+    private ResponseEntity<ErrorResponse> createResponse(String errorMsg, HttpStatus httpStatus) {
+        return ResponseEntity.status(httpStatus).body(new ErrorResponse(errorMsg));
+    }
+
+    @ExceptionHandler(Exception.class)
     @ResponseBody
-    public ResponseEntity<ErrorResponse> handleFileUploadException(FileUploadException exception) {
+    public ResponseEntity<ErrorResponse> handleOtherException(Exception exception) {
         return createBadRequestResponse(exception.getMessage());
     }
 

--- a/src/test/java/com/eerojala/wordcount/api/helper/TestUtil.java
+++ b/src/test/java/com/eerojala/wordcount/api/helper/TestUtil.java
@@ -1,5 +1,6 @@
 package com.eerojala.wordcount.api.helper;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.function.Executable;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -12,57 +13,84 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestUtil {
     /**
-     * Reads content from a file with given name.
-     * @param fileName File must be located in src/test/resources or in any of it's subfolders
+     * Reads content from a file with given name. Will fail the test if an exception occurs during file read.
+     * @param fileName File must be located in src/test/resources or in any of it's sub-folders
      * @return
-     * @throws Exception
      */
-    public static String readStringFromFile(String fileName) throws Exception {
+    public static String readStringFromFile(String fileName) {
         return new String(readBytesFromFile(fileName), StandardCharsets.UTF_8);
     }
 
-    private static byte[] readBytesFromFile(String fileName) throws Exception {
+    private static byte[] readBytesFromFile(String fileName) {
         var inputStream = TestUtil.class.getClassLoader().getResourceAsStream(fileName);
 
-        return StreamUtils.copyToByteArray(inputStream);
+        try {
+            return StreamUtils.copyToByteArray(inputStream);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assertions.fail();
+
+            return null;
+        }
     }
 
     /**
-     * Creates a MockMultipartFile with content from a file with given filename
-     * @param fileName File must be located in src/test/resources or in any of it's subfolders
+     * Creates a MockMultipartFile with content from a file with given file name.
+     * The file name is also set to the created MockMultipartFile.
+     * Will fail the test if an exception occurs during file read.
+     * @param fileName File must be located in src/test/resources or in any of it's sub-folders
      * @return
-     * @throws Exception
      */
-    public static MockMultipartFile createMockMultipartFileFromFile(String fileName) throws Exception {
+    public static MockMultipartFile createMockMultipartFileFromFile(String fileName) {
         var fileContent = readBytesFromFile(fileName);
 
-        return createMockMultipartFile(fileContent);
+        return createMockMultipartFile(fileName, fileContent);
     }
 
     /**
-     * Creates a MockMultipartFile with given String content
+     * Creates a MockMultipartFile with given String content and gives it the file name "test.txt".
      * @param content
      * @return
      */
     public static MockMultipartFile createMockMultipartFile(String content) {
-        return createMockMultipartFile(content.getBytes());
+        return createMockMultipartFile("test.txt", content.getBytes());
     }
 
-    private static MockMultipartFile createMockMultipartFile(byte[] content) {
+    /**
+     * Creates a MockMultipartFile with given String content and gives it the given file name.
+     * NOTE: DOES NOT READ FROM A FILE WITH GIVEN FILE NAME!!
+     * @param fileName
+     * @param content
+     * @return
+     */
+    public static MockMultipartFile createMockMultipartFile(String fileName, String content) {
+        return createMockMultipartFile(fileName, content.getBytes());
+    }
+
+    private static MockMultipartFile createMockMultipartFile(String originalFileName, byte[] content) {
         return new MockMultipartFile(
                 "file",
-                "test.txt",
+                originalFileName,
                 MediaType.TEXT_PLAIN_VALUE,
                 content);
     }
 
     /**
-     * Assers that given executable causes an IllegalArgumentException with given error message
+     * Asserts that given executable causes an IllegalArgumentException with given error message.
      * @param executable
      * @param errorMsg
      */
     public static void assertIllegalArgumentException(Executable executable, String errorMsg) {
         assertException(IllegalArgumentException.class, executable, errorMsg);
+    }
+
+    /**
+     * Asserts that given executable causes an NullPointerException with given error message.
+     * @param executable
+     * @param errorMsg
+     */
+    public static void assertNullPointerException(Executable executable, String errorMsg) {
+        assertException(NullPointerException.class, executable, errorMsg);
     }
 
     /**

--- a/src/test/java/com/eerojala/wordcount/api/helper/TestUtil.java
+++ b/src/test/java/com/eerojala/wordcount/api/helper/TestUtil.java
@@ -1,5 +1,6 @@
 package com.eerojala.wordcount.api.helper;
 
+import jakarta.validation.constraints.Null;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.function.Executable;
 import org.springframework.http.MediaType;
@@ -18,6 +19,10 @@ public class TestUtil {
      * @return
      */
     public static String readStringFromFile(String fileName) {
+        if (fileName == null) {
+            throw new NullPointerException("Given file name cannot be null");
+        }
+
         return new String(readBytesFromFile(fileName), StandardCharsets.UTF_8);
     }
 

--- a/src/test/java/com/eerojala/wordcount/api/service/WordCountServiceTest.java
+++ b/src/test/java/com/eerojala/wordcount/api/service/WordCountServiceTest.java
@@ -16,7 +16,7 @@ public class WordCountServiceTest {
     private WordCountService service;
 
     @Test
-    void testCountMostCommonWordsReturnsMostCommonWordsInDescendingOrder() throws Exception {
+    void testCountMostCommonWordsReturnsMostCommonWordsInDescendingOrder() {
         String content = TestUtil.readStringFromFile("sample_text.txt");
         var hello = new WordCount("hello", 6);
         var world = new WordCount("world", 5);
@@ -52,7 +52,7 @@ public class WordCountServiceTest {
     }
 
     @Test
-    void testCountMostCommonWordsWorksIfThereAreMultipleWordsWithSameAmount() throws Exception {
+    void testCountMostCommonWordsWorksIfThereAreMultipleWordsWithSameAmount() {
         String content = "world foo bar bar foo hello";
         var foo = new WordCount("foo", 2);
         var bar = new WordCount("bar", 2);
@@ -78,7 +78,7 @@ public class WordCountServiceTest {
     }
 
     @Test
-    void testCountMostCommonWordsWorksWithNumbers() throws Exception {
+    void testCountMostCommonWordsWorksWithNumbers() {
         String content = TestUtil.readStringFromFile("numbers.txt");
         var one = new WordCount("1", 11);
         var two = new WordCount("2", 10);
@@ -106,7 +106,7 @@ public class WordCountServiceTest {
     }
 
     @Test
-    void testCountMostCommonWordsIgnoresSpecialCharacters() throws Exception {
+    void testCountMostCommonWordsIgnoresSpecialCharacters() {
         String content = TestUtil.readStringFromFile("special_characters.txt");
         var test = new WordCount("test", 14);
 
@@ -115,7 +115,7 @@ public class WordCountServiceTest {
     }
 
     @Test
-    void testCountMostCommonWordsWorksWithUTF8Characters() throws Exception {
+    void testCountMostCommonWordsWorksWithUTF8Characters() {
         String content = TestUtil.readStringFromFile("utf-8.txt");
         var finnish = new WordCount("ääliö", 3);
         var japanese = new WordCount("日本語", 2);
@@ -135,13 +135,19 @@ public class WordCountServiceTest {
     }
 
     @Test
-    void testCountMostCommonWordsRemovesExtraWhitespace() throws Exception {
+    void testCountMostCommonWordsRemovesExtraWhitespace() {
         String content = TestUtil.readStringFromFile("whitespace.txt");
         var foo = new WordCount("foo", 3);
         var bar = new WordCount("bar", 2);
 
         var expected = List.of(foo, bar);
         assertEquals(expected, service.countMostCommonWords(content, 2));
+    }
+
+    @Test
+    void testCountMostCommonWordsThrowsNullPointerExceptionWithNullString() {
+        TestUtil.assertNullPointerException(() -> service.countMostCommonWords(null, 1337),
+                "Given content cannot be null");
     }
 
     @Test

--- a/src/test/java/com/eerojala/wordcount/api/service/WordCountServiceTest.java
+++ b/src/test/java/com/eerojala/wordcount/api/service/WordCountServiceTest.java
@@ -64,7 +64,7 @@ public class WordCountServiceTest {
 
         assertTrue(wordCountAtIndexEitherOr(result, 0, foo, bar));
         assertTrue(wordCountAtIndexEitherOr(result, 1, foo, bar));
-        assertNotEquals(result.get(0), result.get(1)); // Record default equals checks fields
+        assertNotEquals(result.get(0), result.get(1)); // Record equals default implementation compares fields
 
         assertTrue(wordCountAtIndexEitherOr(result, 2, hello, world));
         assertTrue(wordCountAtIndexEitherOr(result, 3, world, hello));

--- a/src/test/java/com/eerojala/wordcount/api/service/WordCountServiceTest.java
+++ b/src/test/java/com/eerojala/wordcount/api/service/WordCountServiceTest.java
@@ -97,6 +97,15 @@ public class WordCountServiceTest {
     }
 
     @Test
+    void testCountMostCommonWordsWorksWithNewlinesAndCarriageReturns() {
+        String content = "\r\ntest\n\n\rtest\rtest\r\n";
+        var test = new WordCount("test", 3);
+
+        var expected = List.of(test);
+        assertEquals(expected, service.countMostCommonWords(content, 1));
+    }
+
+    @Test
     void testCountMostCommonWordsIgnoresSpecialCharacters() throws Exception {
         String content = TestUtil.readStringFromFile("special_characters.txt");
         var test = new WordCount("test", 14);

--- a/src/test/java/com/eerojala/wordcount/api/util/MultipartFileUtilTest.java
+++ b/src/test/java/com/eerojala/wordcount/api/util/MultipartFileUtilTest.java
@@ -1,11 +1,16 @@
 package com.eerojala.wordcount.api.util;
 
+import com.eerojala.wordcount.api.exception.FileReadException;
 import com.eerojala.wordcount.api.helper.TestUtil;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.multipart.MultipartFile;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 public class MultipartFileUtilTest {
@@ -13,9 +18,64 @@ public class MultipartFileUtilTest {
     private MultipartFileUtil util;
 
     @Test
-    void testGetFileContentGetsContentFromFileSuccessfully() throws Exception {
+    void testReadFileContentReadsContentFromTxtFileSuccessfully() {
         String content = "hello world";
         var file = TestUtil.createMockMultipartFile(content);
-        assertEquals(content, util.getFileContent(file));
+        assertEquals(content, util.readFileContent(file));
+    }
+
+    @Test
+    void testReadFileContentReadsUtf8Characters() {
+        String content = "zażółć ääliö 日本語";
+        var file = TestUtil.createMockMultipartFile(content);
+        assertEquals(content, util.readFileContent(file));
+    }
+
+    @Test
+    void testReadFileContentThrowsNullPointerExceptionIfGivenFileIsNull() {
+        TestUtil.assertNullPointerException(() -> util.readFileContent(null), "Given file cannot be null");
+    }
+
+    @Test
+    void testReadFileThrowsFileReadExceptionIfFileReadFails() throws IOException {
+        var fileMock = Mockito.mock(MultipartFile.class);
+        Mockito.when(fileMock.getInputStream()).thenThrow(new NullPointerException("test exception"));
+        TestUtil.assertException(FileReadException.class, () -> util.readFileContent(fileMock),
+                "Error while reading file");
+    }
+
+    @Test
+    void testIsFileTypeValidReturnsTrueIfIsTxtFile() {
+        var file = TestUtil.createMockMultipartFile("test.txt", "hello");
+        assertTrue(util.isValidFileType(file));
+    }
+
+    @Test
+    void testIsFileTypeValidReturnsTrueIfTextFileCaseInsensitive() {
+        var file = TestUtil.createMockMultipartFile("test.TxT", "world");
+        assertTrue(util.isValidFileType(file));
+    }
+
+    @Test
+    void testIsFileTypeValidReturnsFalseIfNotTxtFile() {
+        var file = TestUtil.createMockMultipartFile("test.jpg", "foo");
+        assertFalse(util.isValidFileType(file));
+    }
+
+    @Test
+    void testIsFileTypeValidReturnsFileIfFileExtensionMissing() {
+        var file = TestUtil.createMockMultipartFile("test", "bar");
+        assertFalse(util.isValidFileType(file));
+    }
+
+    @Test
+    void testIsFileTypeValidReturnsFileIfFileNameMissing() {
+        var file = TestUtil.createMockMultipartFile(null, "abc");
+        assertFalse(util.isValidFileType(file));
+    }
+
+    @Test
+    void testIsFileTypeValidThrowsNullPointerExceptionIfGivenFileIsNull() {
+        TestUtil.assertNullPointerException(() -> util.isValidFileType(null), "Given file cannot be null");
     }
 }

--- a/src/test/java/com/eerojala/wordcount/api/web/WordCountControllerTest.java
+++ b/src/test/java/com/eerojala/wordcount/api/web/WordCountControllerTest.java
@@ -113,7 +113,7 @@ public class WordCountControllerTest {
     }
 
     @Test
-    void testFailsWithNullFile() throws Exception {
+    void testFailsWithNullFile() {
         var request = createMockRequest(null,"1");
         sendRequestExpectError(request, "file: 'must not be null'");
     }


### PR DESCRIPTION
- Fixed bug where some special characters resulted in being transformed into whitespace
- Now the API only accepts .txt files for the file
- Added cache eviction policy, cache holds a maximum of 10,000 WordCounts
- Improved error handling